### PR TITLE
chore: release v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "encoding-checker",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "encoding-checker",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
                 "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "encoding-checker",
     "description": "🔨 Tool to investigate files with different encoding than passed",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "license": "MIT",
     "author": {
         "name": "Piotr Kowalski",
@@ -15,7 +15,8 @@
         "prebuild": "rm -rf dist/ types/",
         "build": "tsc",
         "test": "vitest run",
-        "coverage": "vitest run --coverage"
+        "coverage": "vitest run --coverage",
+        "prepublishOnly": "npm run build"
     },
     "dependencies": {
         "colors": "^1.4.0",


### PR DESCRIPTION
Release after the TypeScript migration (adds type declarations + compiled dist, non-breaking → minor). Adds prepublishOnly build safeguard.