### PR TITLE
docs: add stack badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # encoding-checker
 
+![typescript](https://img.shields.io/badge/built%20with-TypeScript-3178c6.svg)
+
 [![cli-available](https://badgen.net/static/cli/available/?icon=terminal)](#cli)
 [![node version](https://img.shields.io/node/v/encoding-checker.svg)](https://www.npmjs.com/package/encoding-checker)
 [![npm version](https://badge.fury.io/js/encoding-checker.svg)](https://badge.fury.io/js/encoding-checker)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # encoding-checker
 
-![typescript](https://img.shields.io/badge/built%20with-TypeScript-3178c6.svg)
-
 [![cli-available](https://badgen.net/static/cli/available/?icon=terminal)](#cli)
 [![node version](https://img.shields.io/node/v/encoding-checker.svg)](https://www.npmjs.com/package/encoding-checker)
 [![npm version](https://badge.fury.io/js/encoding-checker.svg)](https://badge.fury.io/js/encoding-checker)
@@ -9,6 +7,7 @@
 [![size](https://packagephobia.com/badge?p=encoding-checker)](https://packagephobia.com/result?p=encoding-checker)
 [![license](https://img.shields.io/npm/l/encoding-checker.svg)](https://piecioshka.mit-license.org)
 [![github-ci](https://github.com/piecioshka/encoding-checker/actions/workflows/testing.yml/badge.svg)](https://github.com/piecioshka/encoding-checker/actions/workflows/testing.yml)
+![typescript](https://img.shields.io/badge/built%20with-TypeScript-3178c6.svg)
 
 🔨 Tool to investigate files with different encoding than passed
 


### PR DESCRIPTION
Add stack badges to the README (same style as in other piecioshka projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)