### PR TITLE
ci: drop Node 18 from the test matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 22.x, 24.x]
+                node-version: [20.x, 22.x, 24.x]
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Vitest 4 requires Node `^20 || ^22 || >=24`. Every open Dependabot PR that touches `vitest`, `vite` or `esbuild` fails only on the `build (18.x)` leg while 20.x, 22.x and 24.x pass, which blocks them all.

`find-emails-in-string-cli` already runs 20/22/24, so this brings the matrix in line.

Note: this changes only what CI exercises. `engines` in `package.json` is left alone, because the Node floor comes from the test tooling, not from the published code. Worth a separate decision whether to raise `engines` to `>=20` for consistency - that one is a visible change for a published package.