### PR TITLE
ci: harden the workflow and raise the Node floor to 20

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,9 +9,14 @@ on:
     pull_request:
         branches: ["main"]
 
+concurrency:
+    group: testing-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
 
         strategy:
             matrix:
@@ -19,10 +24,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "url": "git+ssh://git@github.com/piecioshka/encoding-checker.git"
     },
     "engines": {
-        "node": ">=18"
+        "node": ">=20"
     },
     "files": [
         "bin",


### PR DESCRIPTION
## Workflow

- `actions/setup-node@v3` -> `v7` and `actions/checkout@v4` -> `v7`. v3 still runs on the retired node16 runtime.
- `timeout-minutes: 10` on the job. The default is 6 hours, and a hung step burning that is not theoretical - it happened five times today in `photo-map-location-viewer` and `roads-orchestrator`.
- `concurrency` with `cancel-in-progress`, so a new push supersedes the previous run on the same ref.

## engines

Node 18 came out of the test matrix because Vitest 4 requires `^20 || ^22 || >=24`, which left `engines` declaring a floor that nothing verifies any more. Raising it to `>=20` brings the declaration back in line with what CI actually exercises, and matches `find-emails-in-string-cli`.

This is a visible change for a published package, so it is worth a version bump on the next release.

Only `engines` and the workflow change - the rest of `package.json` is untouched, and the files keep their existing indentation (these repos have no prettier config).