### PR TITLE
ci: limit GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,9 @@ on:
     pull_request:
         branches: ["main"]
 
+permissions:
+    contents: read
+
 concurrency:
     group: testing-${{ github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
Chroniony main wymaga PR-a. Zmiana: dodanie `permissions: contents: read` do workflowu testowego.